### PR TITLE
Fix this script for Linux

### DIFF
--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -21,6 +21,7 @@ function! s:unite_source.hooks.on_close(args, context)
 endfunction
 
 function! s:unite_source.gather_candidates(args, context)
+  let initial_guifont_size = split(&guifont, ' ')[-1]
   if has('gui_macvim')
     let list = split(glob('/Library/Fonts/*'), "\n")
     let list = extend(list, split(glob('/System/Library/Fonts/*'), "\n"))
@@ -32,7 +33,7 @@ function! s:unite_source.gather_candidates(args, context)
     " 'fc-list' for win32 is included 'gtk win32 runtime'.
     " see: http://www.gtk.org/download-windows.html
     let list = split(iconv(system('fc-list :spacing=mono'), 'utf-8', &encoding), "\n")
-    if v:lang =~ '^\(ja\|ko\|zh\)' 
+    if v:lang =~ '^\(ja\|ko\|zh\)'
       let list += split(iconv(system('fc-list :spacing=90'), 'utf-8', &encoding), "\n")
     endif
     call map(list, "substitute(v:val, '^.*: ', '', '')")
@@ -46,7 +47,7 @@ function! s:unite_source.gather_candidates(args, context)
   \ "word": v:val,
   \ "source": "font",
   \ "kind": "command",
-  \ "action__command": "let &guifont=" . string(v:val),
+  \ "action__command": "let &guifont=" . string(v:val . " " . initial_guifont_size),
   \ }')
 endfunction
 

--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -31,7 +31,7 @@ function! s:unite_source.gather_candidates(args, context)
   elseif executable('fc-list')
     " 'fc-list' for win32 is included 'gtk win32 runtime'.
     " see: http://www.gtk.org/download-windows.html
-    let list = split(iconv(system('fc-list :spacing=100'), 'utf-8', &encoding), "\n")
+    let list = split(iconv(system('fc-list :spacing=mono'), 'utf-8', &encoding), "\n")
     if v:lang =~ '^\(ja\|ko\|zh\)' 
       let list += split(iconv(system('fc-list :spacing=90'), 'utf-8', &encoding), "\n")
     endif

--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -21,7 +21,7 @@ function! s:unite_source.hooks.on_close(args, context)
 endfunction
 
 function! s:unite_source.gather_candidates(args, context)
-  let initial_guifont_size = split(&guifont, ' ')[-1]
+  let initial_guifont_size = ''
   if has('gui_macvim')
     let list = split(glob('/Library/Fonts/*'), "\n")
     let list = extend(list, split(glob('/System/Library/Fonts/*'), "\n"))
@@ -38,6 +38,7 @@ function! s:unite_source.gather_candidates(args, context)
     endif
     call map(list, "substitute(v:val, '^.*: ', '', '')")
     call map(list, "substitute(v:val, '[:,].*', '', '')")
+    let initial_guifont_size = ' ' . split(&guifont, ' ')[-1]
   else
     echoerr 'Your environment does not support the current version of unite-font.'
     finish
@@ -47,7 +48,7 @@ function! s:unite_source.gather_candidates(args, context)
   \ "word": v:val,
   \ "source": "font",
   \ "kind": "command",
-  \ "action__command": "let &guifont=" . string(v:val . " " . initial_guifont_size),
+  \ "action__command": "let &guifont=" . string(v:val  . initial_guifont_size),
   \ }')
 endfunction
 

--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -21,7 +21,6 @@ function! s:unite_source.hooks.on_close(args, context)
 endfunction
 
 function! s:unite_source.gather_candidates(args, context)
-  let initial_guifont_size = ''
   if has('gui_macvim')
     let list = split(glob('/Library/Fonts/*'), "\n")
     let list = extend(list, split(glob('/System/Library/Fonts/*'), "\n"))
@@ -36,9 +35,8 @@ function! s:unite_source.gather_candidates(args, context)
     if v:lang =~ '^\(ja\|ko\|zh\)'
       let list += split(iconv(system('fc-list :spacing=90'), 'utf-8', &encoding), "\n")
     endif
-    call map(list, "substitute(v:val, '^.*: ', '', '')")
-    call map(list, "substitute(v:val, '[:,].*', '', '')")
-    let initial_guifont_size = ' ' . split(&guifont, ' ')[-1]
+    let font_size = ' ' . split(&guifont, ' ')[-1]
+    call map(list, "substitute(substitute(v:val, '^.*: ', '', ''), '[:,].*', '', '') . l:font_size")
   else
     echoerr 'Your environment does not support the current version of unite-font.'
     finish
@@ -48,7 +46,7 @@ function! s:unite_source.gather_candidates(args, context)
   \ "word": v:val,
   \ "source": "font",
   \ "kind": "command",
-  \ "action__command": "let &guifont=" . string(v:val  . initial_guifont_size),
+  \ "action__command": "let &guifont=" . string(v:val),
   \ }')
 endfunction
 

--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -31,10 +31,11 @@ function! s:unite_source.gather_candidates(args, context)
   elseif executable('fc-list')
     " 'fc-list' for win32 is included 'gtk win32 runtime'.
     " see: http://www.gtk.org/download-windows.html
-    let list = split(iconv(system('fc-list :spacing=mono'), 'utf-8', &encoding), "\n")
+    let list = split(iconv(system('fc-list :spacing=100'), 'utf-8', &encoding), "\n")
     if v:lang =~ '^\(ja\|ko\|zh\)' 
       let list += split(iconv(system('fc-list :spacing=90'), 'utf-8', &encoding), "\n")
     endif
+    call map(list, "substitute(v:val, '^.*: ', '', '')")
     call map(list, "substitute(v:val, '[:,].*', '', '')")
   else
     echoerr 'Your environment does not support the current version of unite-font.'


### PR DESCRIPTION
Your code didn't work for me (Ubuntu 15.04). Then I checked the forks, and @miyakogi's fork worked for me, and the changes are pretty simple, so it should be very straightforward to merge.

For future reference, this is an excerpt of `fc-list` output on my machine:

    /usr/share/fonts/truetype/inconsolata/Inconsolata.otf: Inconsolata:style=Medium
    /usr/share/fonts/truetype/msttcorefonts/Courier_New_Bold_Italic.ttf: Courier New:style=Bold Italic,Negreta cursiva,tučné kurzíva,fed kursiv,Fett Kursiv,Έντονα Πλάγια,Negrita Cursiva,Lihavoitu Kursivoi,Gras Italique,Félkövér dőlt,Grassetto Corsivo,Vet Cursief,Halvfet Kursiv,Pogrubiona kursywa,Negrito Itálico,Полужирный Курсив,Tučná kurzíva,Fet Kursiv,Kalın İtalik,Krepko poševno,Lodi etzana
