### PR TITLE
sort + uniq

### DIFF
--- a/autoload/unite/sources/font.vim
+++ b/autoload/unite/sources/font.vim
@@ -42,6 +42,12 @@ function! s:unite_source.gather_candidates(args, context)
     finish
   endif
 
+  call sort(list)
+  if exists('*uniq')
+    " Added around Vim 7.4.218
+    call uniq(list)
+  endif
+
   return map(list, '{
   \ "word": v:val,
   \ "source": "font",


### PR DESCRIPTION
Sorting the list of fonts. And also removing duplicates.

This is VERY useful on my Linux system.

Supposedly, `uniq()` was added on Vim version 7.4.218, which has been a few years ago. I've decided to add that if clause just to improve compatibility just in case someone still runs a very old version.
